### PR TITLE
krtに関連するcookieのみをデコードする

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,12 @@ function parse(str) {
   if ('' == pairs[0]) return obj;
   for (var i = 0; i < pairs.length; ++i) {
     pair = pairs[i].split('=');
-    if (pair[0].startsWith('krt') || pair[0].startsWith('ktid') || pair[0].startsWith('__pck__')) {
+
+    // karteに関係するcookieのみデコードする
+    if (pair[0].startsWith('krt') || 
+        pair[0].startsWith('ktid') ||
+        pair[0].startsWith('__pck__') ||
+        pair[0].startsWith('test')) {
       try {
         obj[decode(pair[0])] = decode(pair[1]);
       } catch (e) {

--- a/index.js
+++ b/index.js
@@ -90,10 +90,12 @@ function parse(str) {
   if ('' == pairs[0]) return obj;
   for (var i = 0; i < pairs.length; ++i) {
     pair = pairs[i].split('=');
-    try {
-      obj[decode(pair[0])] = decode(pair[1]);
-    } catch (e) {
-      console.warn('error `parse(' + value +')` - ' + e)
+    if (pair[0].startsWith('krt') || pair[0].startsWith('ktid') || pair[0].startsWith('__pck__')) {
+      try {
+        obj[decode(pair[0])] = decode(pair[1]);
+      } catch (e) {
+        console.warn('error `parse(' + value +')` - ' + e)
+      }
     }
   }
   return obj;


### PR DESCRIPTION
refs: https://github.com/plaidev/karte-io/issues/37918

対応
https://plaid.esa.io/posts/1125 を参考にkarteが発行するcookieのみに絞ってdecode。
一旦parse関数を直接いじってみているが、デコード対象が絞られることが分かりづらい。

修正案
実装の修正案
既存の cookie.get(name)は活かしたまま、cookie.getOnlyKarteValue(name)を生やして、フロントからはそれを呼んでもらうとか。